### PR TITLE
Fix the NewTicker race and add regression tests.

### DIFF
--- a/clockwork.go
+++ b/clockwork.go
@@ -152,7 +152,7 @@ func (fc *fakeClock) NewTicker(d time.Duration) Ticker {
 		clock:  fc,
 		period: d,
 	}
-	go ft.tick()
+	ft.runTickThread()
 	return ft
 }
 

--- a/ticker_test.go
+++ b/ticker_test.go
@@ -39,7 +39,7 @@ func TestFakeTickerTick(t *testing.T) {
 		if tick != first {
 			t.Errorf("wrong tick time, got: %v, want: %v", tick, first)
 		}
-	default:
+	case <-time.After(time.Millisecond):
 		t.Errorf("expected tick!")
 	}
 
@@ -52,7 +52,7 @@ func TestFakeTickerTick(t *testing.T) {
 		if tick != second {
 			t.Errorf("wrong tick time, got: %v, want: %v", tick, second)
 		}
-	default:
+	case <-time.After(time.Millisecond):
 		t.Errorf("expected tick!")
 	}
 	ft.Stop()


### PR DESCRIPTION
This fixes the race described by #17. The test provided in that issue is
added along with another similar test that also reproduced the racy
behavior.

The fix is to synchronously create the wait channel for the ticker
rather that lazily create it. This must also occur on each tick: the
next waiter must be initialized before the tick is sent.

Fixes https://github.com/jonboulle/clockwork/issues/17